### PR TITLE
fix RuntimeErrors from msal package

### DIFF
--- a/fastapi_msal/auth.py
+++ b/fastapi_msal/auth.py
@@ -97,7 +97,7 @@ class MSALAuthorization:
     async def check_authenticated_session(self, request: Request) -> bool:
         auth_token: Optional[AuthToken] = await self.get_session_token(request)
         if auth_token and auth_token.id_token:
-            token_claims = self.handler.parse_id_token(
+            token_claims = self.handler.get_id_token_claims(
                 request=request, token=auth_token
             )
             if token_claims:

--- a/fastapi_msal/security/msal_auth_code_handler.py
+++ b/fastapi_msal/security/msal_auth_code_handler.py
@@ -1,8 +1,7 @@
 from typing import Optional, Union, List
 
-from msal import SerializableTokenCache  # type: ignore
 from fastapi import Request, HTTPException, status
-
+from msal import SerializableTokenCache  # type: ignore
 from starlette.responses import RedirectResponse
 
 from fastapi_msal.clients import AsyncConfClient
@@ -57,27 +56,30 @@ class MSALAuthCodeHandler:
         self._save_cache(session=request.session, cache=cache)
         return auth_token
 
-    # TODO: needs rewrite of method, probably seperate into 2 different methods
-    async def parse_id_token(
-        self, request: Request, token: Union[AuthToken, str], validate: bool = True
-    ) -> Optional[IDTokenClaims]:
+    async def get_id_token_claims(self, request: Request, token: Union[AuthToken, str]) -> Optional[IDTokenClaims]:
         if isinstance(token, AuthToken):
             id_token: str = token.id_token
         else:
             id_token = token
+
+        claims: Optional[IDTokenClaims] = await self.get_id_claims_from_session(id_token, request)
+        if claims:
+            return claims
+
+        try:
+            token_claims = await self.msal_app().get_token_claims(id_token=id_token)
+            return IDTokenClaims.parse_obj(token_claims)
+        except RuntimeError as e:
+            # raise e and be more specific with http exceptions or:
+            return None
+
+    async def get_id_claims_from_session(self, id_token, request) -> Optional[IDTokenClaims]:
         auth_token: Optional[AuthToken] = await self.get_token_from_session(
             request=request
         )
-        if (
-            auth_token
-            and auth_token.id_token == id_token
-            and auth_token.id_token_claims
-            and not validate
-        ):
+        if auth_token and auth_token.id_token == id_token and auth_token.id_token_claims:
             return auth_token.id_token_claims
-        if validate:
-            return await self.msal_app().validate_id_token(id_token=id_token)
-        return self.msal_app().decode_id_token(id_token=id_token)
+        return None
 
     def logout(self, request: Request, callback_url: str) -> RedirectResponse:
         SessionManager(request=request).clear()
@@ -104,12 +106,12 @@ class MSALAuthCodeHandler:
             session["token_cache"] = cache.serialize()
 
     def msal_app(
-        self, cache: Optional[SerializableTokenCache] = None
+            self, cache: Optional[SerializableTokenCache] = None
     ) -> AsyncConfClient:
         return AsyncConfClient(client_config=self.client_config, cache=cache)
 
     async def _get_token_from_cache(
-        self, session: StrsDict, user_id: OptStr = None
+            self, session: StrsDict, user_id: OptStr = None
     ) -> Optional[AuthToken]:
         cache: SerializableTokenCache = self._load_cache(session=session)
         acc: AsyncConfClient = self.msal_app(cache=cache)

--- a/fastapi_msal/security/msal_scheme.py
+++ b/fastapi_msal/security/msal_scheme.py
@@ -44,8 +44,8 @@ class MSALScheme(SecurityBase):
         scheme, token = get_authorization_scheme_param(authorization)
         if not authorization or scheme.lower() != "bearer":
             raise http_exception
-        token_claims: Optional[IDTokenClaims] = await self.handler.parse_id_token(
-            request=request, token=token, validate=True
+        token_claims: Optional[IDTokenClaims] = await self.handler.get_id_token_claims(
+            request=request, token=token
         )
         if not token_claims:
             raise http_exception


### PR DESCRIPTION
MSALAuthCodeHandler.parse_id_token rewritten into different functions.

AsyncConfClient.validate_id_token raised uncaught RuntimeError from the msal package whenever a invalid token was presented.

Rearanged some things so there is a None for token_claims returned, as expected, instead of the the exception


