### PR TITLE
Support setting config values in a .env file

### DIFF
--- a/fastapi_msal/core/msal_client_config.py
+++ b/fastapi_msal/core/msal_client_config.py
@@ -35,6 +35,10 @@ class MSALClientConfig(BaseSettings):
     app_name: OptStr = None
     app_version: OptStr = None
 
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+
     @property
     def authority(self) -> str:
         if not self.policy:


### PR DESCRIPTION
This is useful for me, as in development mode I can consolidate all my runtime variables in one .env file, including the MSAL config.