### PR TITLE
Role-based access control (RBAC) authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ As a result the pacage was built around simplicity and ease of use on the expens
 1. Include a dependency class to authenticate and secure your application APIs
 1. Includes a pydantic setting class for easy and secure configuration from your ENV (or .env or secrets directory)
 1. Full support with FastAPI swagger documentations and authentication simulation
+1. Includes Role-Based Access Control (RBAC) authorization
 
 ## Installation
 
@@ -49,8 +50,9 @@ pipenv install "fastapi_msal[full]"
 
 ## Usage
 1. Follow the application [registration process
-with the microsoft identity platform.](https://docs.microsoft.com/azure/active-directory/develop/quickstart-v2-register-an-app)
-Finishing the processes will allow you to retrieve your app_code and app_credentials (app_secret)
+with the microsoft identity platform](https://docs.microsoft.com/azure/active-directory/develop/quickstart-v2-register-an-app)
+and [expose your API.](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-configure-app-expose-web-apis)
+Finishing the processes will allow you to retrieve your app_code, app_credentials (app_secret) and your API scope.
 As well as register your app callback path with the platform.
 
 2. Create a new main.py file and add the following lines.
@@ -65,6 +67,7 @@ client_config: MSALClientConfig = MSALClientConfig()
 client_config.client_id = "The Client ID rerived at step #1"
 client_config.client_credential = "The Client secret retrived at step #1"
 client_config.tenant = "Your tenant id"
+client_config.scopes = ["Scope defined by your API (e.g. {client_id}/Read)"]
 
 app = FastAPI()
 app.add_middleware(SessionMiddleware, secret_key="SOME_SSH_KEY_ONLY_YOU_KNOW")  # replace with your own!!!
@@ -73,7 +76,7 @@ app.include_router(msal_auth.router)
 
 
 @app.get("/users/me", response_model=UserInfo, response_model_exclude_none=True, response_model_by_alias=False)
-async def read_users_me(current_user: UserInfo = Depends(msal_auth.scheme)) -> UserInfo:
+async def read_users_me(current_user: UserInfo = Depends(msal_auth.scheme())) -> UserInfo:
     return current_user
 
 

--- a/fastapi_msal/auth.py
+++ b/fastapi_msal/auth.py
@@ -83,7 +83,7 @@ class MSALAuthorization:
         token: AuthToken = await self.handler.authorize_access_token(
             request=request, code=code
         )
-        return BearerToken(access_token=token.id_token)
+        return BearerToken(access_token=token.access_token)
 
     async def _logout_route(
         self, request: Request, referer: OptStr = Header(None)
@@ -104,10 +104,10 @@ class MSALAuthorization:
                 return True
         return False
 
-    @property
-    def scheme(self) -> MSALScheme:
+    def scheme(self, required_role: Optional[str] = None) -> MSALScheme:
         return MSALScheme(
             authorizationUrl=self.router.url_path_for("_login_route"),
             tokenUrl=self.router.url_path_for("_post_token_route"),
             handler=self.handler,
+            required_role=required_role
         )

--- a/fastapi_msal/core/msal_client_config.py
+++ b/fastapi_msal/core/msal_client_config.py
@@ -35,6 +35,10 @@ class MSALClientConfig(BaseSettings):
     app_name: OptStr = None
     app_version: OptStr = None
 
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+
     @property
     def authority(self) -> str:
         if not self.policy:

--- a/fastapi_msal/models/id_token_claims.py
+++ b/fastapi_msal/models/id_token_claims.py
@@ -1,7 +1,7 @@
 from typing import Optional
 from datetime import datetime
 from pydantic import BaseModel, Field
-from fastapi_msal.core import OptStr, MSALPolicies
+from fastapi_msal.core import OptStr, OptStrList, MSALPolicies
 from .user_info import UserInfo
 
 
@@ -23,6 +23,16 @@ class AADInternalClaims(BaseModel):
 
 
 class IDTokenClaims(UserInfo, AADInternalClaims):
+    roles: OptStrList = None
+    """"
+    The set of roles that were assigned to the user who is logging in.
+    """
+
+    scp: OptStr = None
+    """
+    The set of scopes exposed by your application for which the client application has requested (and received) consent.
+    """
+
     exp: Optional[datetime] = None
     """
     The expiration time claim is the time at which the token becomes invalid, represented in epoch time.


### PR DESCRIPTION
### Adding authorization based on Role claims in the access_token

This pull request aims to add the authorization part which is based on the [access_token](https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens) rather than the [id_token](https://docs.microsoft.com/en-us/azure/active-directory/develop/id-tokens).
From the Microsoft documentation : _"ID tokens should not be used for authorization purposes. Access tokens are used for authorization"_

This first change (using access_token instead of id_token) implies the client application (Swagger UI, CLI, Web app...) to request an access_token with a valid scope ([how to expose your API - add a scope](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-configure-app-expose-web-apis)). The API then can perform the requested operation only if the access token it receives contains the scopes required.

First level of authZ is to grant or deny access based on whether the entity making a request has been authenticated:
`Depends(msal_auth.scheme())`

Second level of authZ is to grant access to specific roles using the `roles` [claims](https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens#payload-claims) in the access_token:
`Depends(msal_auth.scheme(required_role = "specific_role"))`

Thanks in advance for having a look at this PR.