### PR TITLE
Session backends (+file cache)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ pipenv install "fastapi_msal[full]"
    2. [itsdangerous](https://github.com/pallets/itsdangerous)
    Used by Starlette [session middleware](https://www.starlette.io/middleware/)
 
+   3. [aiofiles](https://pypi.org/project/aiofiles/): Used to save session data to the file system when enabled. FastAPI also uses this library to load static files.
+
 ## Usage
 1. Follow the application [registration process
 with the microsoft identity platform.](https://docs.microsoft.com/azure/active-directory/develop/quickstart-v2-register-an-app)

--- a/fastapi_msal/auth.py
+++ b/fastapi_msal/auth.py
@@ -89,7 +89,7 @@ class MSALAuthorization:
         self, request: Request, referer: OptStr = Header(None)
     ) -> RedirectResponse:
         callback_url = referer if referer else str(self.return_to_path)
-        return self.handler.logout(request=request, callback_url=callback_url)
+        return await self.handler.logout(request=request, callback_url=callback_url)
 
     async def get_session_token(self, request: Request) -> Optional[AuthToken]:
         return await self.handler.get_token_from_session(request=request)

--- a/fastapi_msal/core/__init__.py
+++ b/fastapi_msal/core/__init__.py
@@ -1,3 +1,3 @@
 from .utils import OptStr, OptStrList, StrList, OptStrsDict, StrsDict
-from .msal_client_config import MSALPolicies, MSALClientConfig
+from .msal_client_config import MSALPolicies, MSALClientConfig, MSALSessionType
 from .session_manager import SessionManager

--- a/fastapi_msal/core/msal_client_config.py
+++ b/fastapi_msal/core/msal_client_config.py
@@ -13,7 +13,7 @@ class MSALPolicies(str, Enum):
     B2C_PROFILE = "B2C_1_PROFILE"
 
 
-class SessionType(str, Enum):
+class MSALSessionType(str, Enum):
     IN_MEMORY = "memory"
     FILE = "filesystem"
 
@@ -30,7 +30,7 @@ class MSALClientConfig(BaseSettings):
     # Optional to set - If you are unsure don't set - it will be filled by MSAL as required
     scopes: StrList = list()
     # Optional to set - Defaults to in-memory sessions. See SessionType for options
-    session_type: SessionType = SessionType.IN_MEMORY
+    session_type: MSALSessionType = MSALSessionType.IN_MEMORY
     # Optional to set, only used when session_type is filesystem
     # Specifies the folder path session data is saved
     session_file_path: Path = Path("session")
@@ -68,11 +68,11 @@ class MSALClientConfig(BaseSettings):
         return f"{self.path_prefix}{self.login_path}"
 
     def make_session_backend(self) -> SessionBackend:
-        if self.session_type is SessionType.IN_MEMORY:
+        if self.session_type is MSALSessionType.IN_MEMORY:
             from .session.inmemory import InMemorySessionBackend
 
             return InMemorySessionBackend(self)
-        elif self.session_type is SessionType.FILE:
+        elif self.session_type is MSALSessionType.FILE:
             from .session.filesystem import FileSessionBackend
 
             return FileSessionBackend(self)

--- a/fastapi_msal/core/session/__init__.py
+++ b/fastapi_msal/core/session/__init__.py
@@ -1,0 +1,1 @@
+from .base import SessionBackend

--- a/fastapi_msal/core/session/base.py
+++ b/fastapi_msal/core/session/base.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # msal_client_config.py imports this module, so guard against recursive imports
+    from ..msal_client_config import MSALClientConfig
+    from ..utils import OptStrsDict, StrsDict
+
+
+class SessionBackend(ABC):
+    def __init__(self, settings: MSALClientConfig):
+        self.settings = settings
+
+    @abstractmethod
+    async def write(self, key: str, value: StrsDict) -> None:
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def read(self, key: str) -> OptStrsDict:
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def remove(self, key: str) -> None:
+        raise NotImplementedError()

--- a/fastapi_msal/core/session/filesystem.py
+++ b/fastapi_msal/core/session/filesystem.py
@@ -1,0 +1,57 @@
+import json
+from pathlib import Path
+
+from ..utils import OptStr, OptStrsDict, StrsDict
+from .base import SessionBackend
+
+try:
+    import aiofiles
+    import aiofiles.os
+    import aiofiles.ospath
+except ImportError:
+    raise ImportError(
+        "aiofiles is required for file sessions. Install it using 'pip install aiofiles'."
+    )
+
+
+class FileSessionBackend(SessionBackend):
+    """A session backend that saves session data to the filesystem.
+
+    aiofiles is required to use. Install it using "pip install aiofiles".
+
+    Config:
+        file_path: Path - the directory session data will be saved
+
+    """
+
+    async def get_file(self, key: str) -> Path:
+        await aiofiles.os.makedirs(self.settings.session_file_path, exist_ok=True)
+        return self.settings.session_file_path / f"{key}.json"
+
+    async def write(self, key: str, value: StrsDict) -> None:
+        file = await self.get_file(key)
+        value_json: str = json.dumps(value)
+        await writetext(file, value_json)
+
+    async def read(self, key: str) -> OptStrsDict:
+        file = await self.get_file(key)
+        value_json = await readtext(file)
+        if value_json:
+            return json.loads(value_json)
+        return None
+
+    async def remove(self, key: str) -> None:
+        file = await self.get_file(key)
+        await aiofiles.os.remove(file)
+
+
+async def readtext(path: Path) -> OptStr:
+    if await aiofiles.ospath.exists(path):
+        async with aiofiles.open(path) as f:
+            return await f.read()
+    return None
+
+
+async def writetext(path: Path, text: str):
+    async with aiofiles.open(path) as f:
+        await f.write(text)

--- a/fastapi_msal/core/session/filesystem.py
+++ b/fastapi_msal/core/session/filesystem.py
@@ -47,11 +47,11 @@ class FileSessionBackend(SessionBackend):
 
 async def readtext(path: Path) -> OptStr:
     if await aiofiles.ospath.exists(path):
-        async with aiofiles.open(path) as f:
+        async with aiofiles.open(path, 'r') as f:
             return await f.read()
     return None
 
 
 async def writetext(path: Path, text: str):
-    async with aiofiles.open(path) as f:
+    async with aiofiles.open(path, 'w') as f:
         await f.write(text)

--- a/fastapi_msal/core/session/inmemory.py
+++ b/fastapi_msal/core/session/inmemory.py
@@ -1,0 +1,29 @@
+import json
+
+from ..utils import OptStrsDict, StrsDict
+from .base import SessionBackend
+
+
+class InMemorySessionBackend(SessionBackend):
+    """A session backend implementation which stores session data in-memory via
+    a dict.
+
+    All methods are effectively synchronous, so locking does not need to happen.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.cache_db: StrsDict = {}
+
+    async def write(self, key: str, value: StrsDict) -> None:
+        value_json: str = json.dumps(value)
+        self.cache_db.update({key: value_json})
+
+    async def read(self, key: str) -> OptStrsDict:
+        value_json = self.cache_db.get(key, None)
+        if value_json:
+            return json.loads(value_json)
+        return None
+
+    async def remove(self, key: str) -> None:
+        self.cache_db.pop(key, None)

--- a/fastapi_msal/core/session_manager.py
+++ b/fastapi_msal/core/session_manager.py
@@ -22,14 +22,14 @@ class CacheManager:
         pass
 
     @classmethod
-    def write(
+    async def write(
         cls, key: str, value: StrsDict
     ) -> None:  # TODO: make sure we run this one at a time
         value_json: str = json.dumps(value)
         cls.cache_db.update({key: value_json})
 
     @classmethod
-    def read(
+    async def read(
         cls, key: str
     ) -> Optional[StrsDict]:  # TODO: make sure we run this one at a time
         value_json: OptStr = cls.cache_db.get(key, None)
@@ -38,7 +38,7 @@ class CacheManager:
         return None
 
     @classmethod
-    def remove(cls, key: str) -> None:  # TODO: make sure we run this one at a time
+    async def remove(cls, key: str) -> None:  # TODO: make sure we run this one at a time
         cls.cache_db.pop(key, None)
 
 
@@ -54,23 +54,23 @@ class SessionManager:
     def init_session(self, session_id: str) -> None:
         self.request.session.update({SESSION_KEY: session_id})
 
-    def _read_session(self) -> OptStrsDict:
+    async def _read_session(self) -> OptStrsDict:
         if not self.session_id:
             return None
-        session: OptStrsDict = self.cache_manager.read(self.session_id)
+        session: OptStrsDict = await self.cache_manager.read(self.session_id)
         if session:
             return session
         return dict()  # return empty session object
 
-    def _write_session(self, session: StrsDict) -> None:
+    async def _write_session(self, session: StrsDict) -> None:
         if not self.session_id:
             raise IOError(
                 "No session id, (Make sure you initialized the session by calling init_session)"
             )
-        self.cache_manager.write(key=self.session_id, value=session)
+        await self.cache_manager.write(key=self.session_id, value=session)
 
-    def save(self, model: M) -> None:
-        session: OptStrsDict = self._read_session()
+    async def save(self, model: M) -> None:
+        session: OptStrsDict = await self._read_session()
         if session is None:
             raise IOError(
                 "No session id, (Make sure you initialized the session by calling init_session)"
@@ -78,21 +78,21 @@ class SessionManager:
         session.update(
             {model.__repr_name__(): model.json(exclude_none=True, by_alias=True)}
         )
-        self._write_session(session=session)
+        await self._write_session(session=session)
 
-    def load(self, model_cls: Type[M]) -> Optional[M]:
-        session: OptStrsDict = self._read_session()
+    async def load(self, model_cls: Type[M]) -> Optional[M]:
+        session: OptStrsDict = await self._read_session()
         if session:
             raw_model: OptStr = session.get(model_cls.__name__, None)
             if raw_model:
                 return model_cls.parse_raw(raw_model)
         return None
 
-    def clear(self) -> None:
+    async def clear(self) -> None:
         session_id = self.session_id
         if not session_id:
             return  # there is no session to clear
         # clear the session object from cache
-        self.cache_manager.remove(session_id)
+        await self.cache_manager.remove(session_id)
         # clear the session_id from the session cookie
         self.request.session.pop(SESSION_KEY, None)

--- a/fastapi_msal/models/base_auth_model.py
+++ b/fastapi_msal/models/base_auth_model.py
@@ -15,10 +15,10 @@ class BaseAuthModel(BaseModel):
         return debug_model
 
     async def save_to_session(self: AuthModel, session: SessionManager) -> None:
-        session.save(self)
+        await session.save(self)
 
     @classmethod
     async def load_from_session(
         cls: Type[AuthModel], session: SessionManager
     ) -> Optional[AuthModel]:
-        return session.load(model_cls=cls)
+        return await session.load(model_cls=cls)

--- a/fastapi_msal/security/msal_auth_code_handler.py
+++ b/fastapi_msal/security/msal_auth_code_handler.py
@@ -79,8 +79,8 @@ class MSALAuthCodeHandler:
             return await self.msal_app().validate_id_token(id_token=id_token)
         return self.msal_app().decode_id_token(id_token=id_token)
 
-    def logout(self, request: Request, callback_url: str) -> RedirectResponse:
-        SessionManager(request=request).clear()
+    async def logout(self, request: Request, callback_url: str) -> RedirectResponse:
+        await SessionManager(request=request).clear()
         logout_url = f"{self.client_config.authority}/oauth2/v2.0/logout?post_logout_redirect_uri={callback_url}"
         return RedirectResponse(url=logout_url)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,8 @@ requires-python = ">=3.7"
 [tool.flit.metadata.requires-extra]
 full = [
     "python-multipart",
-    "itsdangerous"
+    "itsdangerous",
+    "aiofiles"
 ]
 dev = [
     "black",


### PR DESCRIPTION
This PR adds support for a persistent session cache via aiofiles. To use, install aiofiles `pip install aiofiles` and configure MSALClientConfig.

```py
from fastapi_msal.core import MSALClientConfig

config = MSALClientConfig(
    session_type="filesystem",
    session_file_path="path/to/sessions",
)
msal_auth = MSALAuthorization(config)
```

If using a config file like `.env`:
```shell
SESSION_TYPE=filesystem
SESSION_FILE_PATH=/path/to/sessions
```
```py
from fastapi_msal import MSALClientConfig

settings = MSALClientConfig(_env_file=".env")
```