### PR TITLE
ENH: add exception catch to handle all kinds of JWT token validation failure.

### DIFF
--- a/fastapi_msal/security/msal_scheme.py
+++ b/fastapi_msal/security/msal_scheme.py
@@ -44,9 +44,12 @@ class MSALScheme(SecurityBase):
         scheme, token = get_authorization_scheme_param(authorization)
         if not authorization or scheme.lower() != "bearer":
             raise http_exception
-        token_claims: Optional[IDTokenClaims] = await self.handler.parse_id_token(
-            request=request, token=token, validate=True
-        )
+        try:
+            token_claims: Optional[IDTokenClaims] = await self.handler.parse_id_token(
+                request=request, token=token, validate=True
+            )
+        except Exception as e:
+            raise http_exception
         if not token_claims:
             raise http_exception
         return token_claims


### PR DESCRIPTION
ENH: add exception catch to handle all kinds of JWT token validation failure.
This will solve https://github.com/dudil/fastapi_msal/issues/15
