### PR TITLE
Fix redirect uri type as the URL is serializable to String

### DIFF
--- a/fastapi_msal/auth.py
+++ b/fastapi_msal/auth.py
@@ -62,7 +62,7 @@ class MSALAuthorization:
         if client_id:
             print(client_id)
         if not redirect_uri:
-            redirect_uri = request.url_for("_get_token_route")
+            redirect_uri = str(request.url_for("_get_token_route"))
         return await self.handler.authorize_redirect(
             request=request, redirec_uri=redirect_uri, state=state
         )


### PR DESCRIPTION
As seen with issue https://github.com/dudil/fastapi_msal/issues/23 the API of fastapi changed to return `starlette.datastructures.URL` instead of string. This serializes the URL to string and is backwards compatible with the older version as well.