### PR TITLE
Add rbac (fixes #11)

### DIFF
--- a/fastapi_msal/auth.py
+++ b/fastapi_msal/auth.py
@@ -95,3 +95,14 @@ class MSALAuthorization:
             token_url=self.router.url_path_for("_post_token_route"),
             handler=self.handler,
         )
+
+    def rbac_allow(self, accepted_roles: Optional[Union[str, list[str]]] = None) -> MSALScheme:
+        """
+        :param accepted_roles: list of roles to accept (at least one is required)  
+        """
+        return MSALScheme(
+            authorization_url=self.router.url_path_for("_login_route"),
+            token_url=self.router.url_path_for("_post_token_route"),
+            handler=self.handler,
+            accepted_roles=accepted_roles,
+        )

--- a/fastapi_msal/models/user_info.py
+++ b/fastapi_msal/models/user_info.py
@@ -72,3 +72,10 @@ class UserInfo(BaseModel):
     """
     Indicated if this is a new user in the system (following a registration on AAD web part e.g.)
     """
+
+    roles: Optional[list[str]] = Field([])
+    """
+    The roles claim if its present - list of strings, each indicating a role assigned to the user
+    https://learn.microsoft.com/en-us/azure/active-directory/develop/howto-add-app-roles-in-apps
+    """
+


### PR DESCRIPTION
Introduces support for rbac via the rbac_allow method - I figured it would be better to introduce a new method and avoid breaking compatibility for the existing property.
I also added a try-except to handle eg. expired tokens with a 401 and some debug info - could have been nicer, but this was better than nothing I figured..

Usage:
```python
@app.get(
    "/users/me",
    response_model=UserInfo,
    response_model_exclude_none=True,
    response_model_by_alias=False,
)
async def read_users_me(
    current_user: UserInfo = Depends(msal_auth.rbac_allow(["api.all.Read"])),
) -> UserInfo:
    return current_user
```

This makes it quite easy to use rbac by simply going from ```msal_auth.scheme``` to ```msal_auth.rbac_allow(["required_role"])```.