### PR TITLE
Respect `callback_url` query param on logout

### DIFF
--- a/fastapi_msal/auth.py
+++ b/fastapi_msal/auth.py
@@ -82,7 +82,7 @@ class MSALAuthorization:
         self, request: Request, referer: Annotated[OptStr, Header()] = None, callback_url: OptStr = None
     ) -> RedirectResponse:
         # check if callback_url is set, if not try to get it from referer header
-        callback_url = referer if referer else str(self.return_to_path)
+        callback_url = callback_url or referer or str(self.return_to_path)
         return self.handler.logout(request=request, callback_url=callback_url)
 
     async def get_session_token(self, request: Request) -> Optional[AuthToken]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ exclude = ["docs/", "/.venv/", "/.vscode/", "/.github/", "/.gitignore", "/.gitat
 
 [project.optional-dependencies]
 full = ["python-multipart", "itsdangerous"]
-dev  = ["fastapi_msal[full]", "black", "ruff", "mypy", "pytest"]
+dev  = ["fastapi_msal[full]", "black", "ruff", "mypy", "pytest", "httpx"]
 
 [tool.hatch.envs.default]
 path         = ".venv"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -9,52 +9,45 @@ from fastapi_msal import MSALAuthorization, MSALClientConfig
 
 
 @pytest.fixture
-def dummy_client_config():
-    return MSALClientConfig()
+def auth():
+    return MSALAuthorization(client_config=MSALClientConfig(), return_to_path="https://www.example.com")
 
 
-def test_return_to_path(dummy_client_config):
-    auth = MSALAuthorization(client_config=dummy_client_config, return_to_path="https://www.example.com")
-
+@pytest.fixture
+def app(auth):
     app = FastAPI()
     app.add_middleware(SessionMiddleware, secret_key="")
     app.include_router(auth.router)
-    client = TestClient(app, follow_redirects=False)
-    response = client.get(app.url_path_for("_logout_route"))
-    assert response.is_redirect
-
-    redirect = urlparse(response.headers.get("Location"))
-    assert parse_qs(redirect.query)["post_logout_redirect_uri"][0] == "https://www.example.com"
+    return app
 
 
-def test_referer_precedence_over_return_to_path(dummy_client_config):
-    auth = MSALAuthorization(client_config=dummy_client_config, return_to_path="https://www.example.com")
+class TestLogoutRedirect:
+    def post_logout_redirect_for(self, response):
+        redirect = urlparse(response.headers.get("Location"))
+        return parse_qs(redirect.query)["post_logout_redirect_uri"][0]
 
-    app = FastAPI()
-    app.add_middleware(SessionMiddleware, secret_key="")
-    app.include_router(auth.router)
-    client = TestClient(app, follow_redirects=False)
-    response = client.get(app.url_path_for("_logout_route"), headers={"Referer": "https://github.com/dudil/fastapi_msal"})
-    assert response.is_redirect
+    @pytest.fixture
+    def get_logout(self, app):
+        def http_get_logout(*, headers=None, params=None):
+            client = TestClient(app, follow_redirects=False)
+            return client.get(app.url_path_for("_logout_route"), headers=headers, params=params)
 
-    redirect = urlparse(response.headers.get("Location"))
-    assert parse_qs(redirect.query)["post_logout_redirect_uri"][0] == "https://github.com/dudil/fastapi_msal"
+        return http_get_logout
 
+    def test_return_to_path(self, get_logout):
+        response = get_logout()
+        assert response.is_redirect
+        assert self.post_logout_redirect_for(response) == "https://www.example.com"
 
-def test_callback_url_takes_precedence_over_referer(dummy_client_config):
-    auth = MSALAuthorization(client_config=dummy_client_config, return_to_path="https://www.example.com")
+    def test_referer_precedence_over_return_to_path(self, get_logout):
+        response = get_logout(headers={"Referer": "https://github.com/dudil/fastapi_msal"})
+        assert response.is_redirect
+        assert self.post_logout_redirect_for(response) == "https://github.com/dudil/fastapi_msal"
 
-    app = FastAPI()
-    app.add_middleware(SessionMiddleware, secret_key="")
-    app.include_router(auth.router)
-    print(app.routes)
-    client = TestClient(app, follow_redirects=False)
-    response = client.get(
-        app.url_path_for("_logout_route"),
-        headers={"Referer": "https://github.com/dudil/fastapi_msal"},
-        params={"callback_url": "https://pypi.org/project/fastapi-msal"},
-    )
-    assert response.is_redirect
-
-    redirect = urlparse(response.headers.get("Location"))
-    assert parse_qs(redirect.query)["post_logout_redirect_uri"][0] == "https://pypi.org/project/fastapi-msal"
+    def test_callback_url_takes_precedence_over_referer(self, get_logout):
+        response = get_logout(
+            headers={"Referer": "https://github.com/dudil/fastapi_msal"},
+            params={"callback_url": "https://pypi.org/project/fastapi-msal"},
+        )
+        assert response.is_redirect
+        assert self.post_logout_redirect_for(response) == "https://pypi.org/project/fastapi-msal"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,27 @@
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.middleware.sessions import SessionMiddleware
+
+from fastapi_msal import MSALAuthorization, MSALClientConfig
+
+
+@pytest.fixture
+def dummy_client_config():
+    return MSALClientConfig()
+
+
+def test_return_to_path(dummy_client_config):
+    auth = MSALAuthorization(client_config=dummy_client_config, return_to_path="https://www.example.com")
+
+    app = FastAPI()
+    app.add_middleware(SessionMiddleware, secret_key="")
+    app.include_router(auth.router)
+    client = TestClient(app, follow_redirects=False)
+    response = client.get(app.url_path_for("_logout_route"))
+    assert response.is_redirect
+
+    redirect = urlparse(response.headers.get("Location"))
+    assert parse_qs(redirect.query)["post_logout_redirect_uri"][0] == "https://www.example.com"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -25,3 +25,36 @@ def test_return_to_path(dummy_client_config):
 
     redirect = urlparse(response.headers.get("Location"))
     assert parse_qs(redirect.query)["post_logout_redirect_uri"][0] == "https://www.example.com"
+
+
+def test_referer_precedence_over_return_to_path(dummy_client_config):
+    auth = MSALAuthorization(client_config=dummy_client_config, return_to_path="https://www.example.com")
+
+    app = FastAPI()
+    app.add_middleware(SessionMiddleware, secret_key="")
+    app.include_router(auth.router)
+    client = TestClient(app, follow_redirects=False)
+    response = client.get(app.url_path_for("_logout_route"), headers={"Referer": "https://github.com/dudil/fastapi_msal"})
+    assert response.is_redirect
+
+    redirect = urlparse(response.headers.get("Location"))
+    assert parse_qs(redirect.query)["post_logout_redirect_uri"][0] == "https://github.com/dudil/fastapi_msal"
+
+
+def test_callback_url_takes_precedence_over_referer(dummy_client_config):
+    auth = MSALAuthorization(client_config=dummy_client_config, return_to_path="https://www.example.com")
+
+    app = FastAPI()
+    app.add_middleware(SessionMiddleware, secret_key="")
+    app.include_router(auth.router)
+    print(app.routes)
+    client = TestClient(app, follow_redirects=False)
+    response = client.get(
+        app.url_path_for("_logout_route"),
+        headers={"Referer": "https://github.com/dudil/fastapi_msal"},
+        params={"callback_url": "https://pypi.org/project/fastapi-msal"},
+    )
+    assert response.is_redirect
+
+    redirect = urlparse(response.headers.get("Location"))
+    assert parse_qs(redirect.query)["post_logout_redirect_uri"][0] == "https://pypi.org/project/fastapi-msal"


### PR DESCRIPTION
Before this change, the query parameter `callback_url`
in MSALAuthorization._logout_route was being ignored
by the logic.

This change now prefers the query parameter first,
ahead of the Referer header and the configured default.

Another alternative would have been to remove the
query parameter, as it was not currently being
acknowledged anyway.

----

Addresses [Question 1](https://github.com/dudil/fastapi_msal/issues/45#issuecomment-2648532425) on #45:

> Question 1: To be 100% sure we're on the same page before I draft the PR, the precedence should be:
> 
> callback_url query parameter
> HTTP referer
> return_to_path
> correct? That seems the most logical to me.