### PR TITLE
Make sure the check_authenticated_session method validates the token

### DIFF
--- a/fastapi_msal/auth.py
+++ b/fastapi_msal/auth.py
@@ -7,6 +7,7 @@ from starlette.responses import RedirectResponse
 from fastapi_msal.core import MSALClientConfig, OptStr
 from fastapi_msal.models import AuthToken, BearerToken, IDTokenClaims
 from fastapi_msal.security import MSALAuthCodeHandler, MSALScheme
+from fastapi_msal.models.id_token_claims import TokenStatus
 
 
 class MSALAuthorization:

--- a/fastapi_msal/auth.py
+++ b/fastapi_msal/auth.py
@@ -92,7 +92,7 @@ class MSALAuthorization:
         auth_token: Optional[AuthToken] = await self.get_session_token(request)
         if auth_token:
             token_claims: Optional[IDTokenClaims] = await self.handler.parse_id_token(token=auth_token)
-            if token_claims and token_claims.validate_token():
+            if token_claims and token.id_token_claims.validate_token() == TokenStatus.VALID:
                 return True
         return False
 

--- a/fastapi_msal/auth.py
+++ b/fastapi_msal/auth.py
@@ -93,7 +93,7 @@ class MSALAuthorization:
         auth_token: Optional[AuthToken] = await self.get_session_token(request)
         if auth_token:
             token_claims: Optional[IDTokenClaims] = await self.handler.parse_id_token(token=auth_token)
-            if token_claims and token.id_token_claims.validate_token() == TokenStatus.VALID:
+            if token_claims and token_claims.validate_token() == TokenStatus.VALID:
                 return True
         return False
 


### PR DESCRIPTION
Make sure the check_authenticated_session method validates the token

An invalid token doesn't stop the check_authenticated_session method from returning false as long as its present. 

This change fixes that. 